### PR TITLE
Refactor bot commands into modules

### DIFF
--- a/lib/food_bot/command_helpers.ex
+++ b/lib/food_bot/command_helpers.ex
@@ -1,0 +1,13 @@
+defmodule FoodBot.CommandHelpers do
+  alias FoodBot.{Repo, Event}
+  import Ecto.Query
+
+  def latest_events_text do
+    Event
+    |> order_by(desc: :inserted_at)
+    |> limit(5)
+    |> Repo.all
+    |> Enum.map(&(" - #{&1.name}"))
+    |> Enum.join("\n")
+  end
+end

--- a/lib/food_bot/commands/join_event_command.ex
+++ b/lib/food_bot/commands/join_event_command.ex
@@ -1,0 +1,48 @@
+defmodule FoodBot.JoinEventCommand do
+  alias FoodBot.{Repo, Event}
+  import FoodBot.CommandHelpers
+  import Ecto.Query
+
+  def name, do: "join_event"
+
+  def execute(nil, state) do
+    {
+      """
+      Sorry, you didn't provide an event name. Is it one of these?
+      #{latest_events_text()}
+      """,
+      state
+    }
+  end
+  def execute(name, state) do
+    event = Event
+            |> preload(:food_sources)
+            |> where(name: ^name)
+            |> limit(1)
+            |> Repo.one
+
+    case event do
+      nil ->
+        {
+          """
+          Sorry, I can't find event "#{name}". Is it one of these?
+          #{latest_events_text()}
+          """,
+          state
+        }
+
+      event ->
+        food_sources_text = event.food_sources
+                            |> Enum.map(&(" - #{&1.name}: #{&1.url}"))
+                            |> Enum.join("\n")
+
+        {
+          """
+          You joined event "#{name}". You can order from:
+          #{food_sources_text}
+          """,
+          Map.put(state, :event, event)
+        }
+    end
+  end
+end

--- a/lib/food_bot/commands/join_event_command.ex
+++ b/lib/food_bot/commands/join_event_command.ex
@@ -3,8 +3,6 @@ defmodule FoodBot.JoinEventCommand do
   import FoodBot.CommandHelpers
   import Ecto.Query
 
-  def name, do: "join_event"
-
   def execute(name, state \\ %{})
   def execute(nil, state) do
     {

--- a/lib/food_bot/commands/join_event_command.ex
+++ b/lib/food_bot/commands/join_event_command.ex
@@ -5,6 +5,7 @@ defmodule FoodBot.JoinEventCommand do
 
   def name, do: "join_event"
 
+  def execute(name, state \\ %{})
   def execute(nil, state) do
     {
       """

--- a/lib/food_bot/commands/not_found_command.ex
+++ b/lib/food_bot/commands/not_found_command.ex
@@ -1,0 +1,5 @@
+defmodule FoodBot.NotFoundCommand do
+  def execute(_ \\ nil, state \\ %{}) do
+    { "Available commands are `join_event` and `order`", state }
+  end
+end

--- a/lib/food_bot/commands/order_command.ex
+++ b/lib/food_bot/commands/order_command.ex
@@ -2,8 +2,6 @@ defmodule FoodBot.OrderCommand do
   alias FoodBot.{Repo, Order}
   import FoodBot.CommandHelpers
 
-  def name, do: "join_event"
-
   def execute(name, state \\ %{})
   def execute(nil, state) do
     { "Sorry, you didn't provide an order.", state }

--- a/lib/food_bot/commands/order_command.ex
+++ b/lib/food_bot/commands/order_command.ex
@@ -1,0 +1,39 @@
+defmodule FoodBot.OrderCommand do
+  alias FoodBot.{Repo, Order}
+  import FoodBot.CommandHelpers
+
+  def name, do: "join_event"
+
+  def execute(name, state \\ %{})
+  def execute(nil, state) do
+    { "Sorry, you didn't provide an order.", state }
+  end
+  def execute(text, state = %{event: event, user: %{name: user_name}}) do
+    case Enum.count event.food_sources do
+      0 -> raise "TODO"
+      1 ->
+        {status, _} = Repo.insert %Order{
+          event: event,
+          food_source: Enum.at(event.food_sources, 0),
+          order: text,
+          user_name: user_name
+        }
+
+        case status do
+          :ok -> { "Your order has been taken. Thank you.", state }
+          :error -> { "Something went wrong while saving your order. :(", state }
+        end
+
+      _ -> raise "TODO"
+    end
+  end
+  def execute(_, state) do
+    {
+      """
+      Sorry, you need to join an event first. Is it one of these?
+      #{latest_events_text()}
+      """,
+      state
+    }
+  end
+end

--- a/lib/food_bot/slack_bot.ex
+++ b/lib/food_bot/slack_bot.ex
@@ -15,6 +15,7 @@ defmodule FoodBot.SlackBot do
 
     {reply, new_state} = cmd
                        |> String.downcase
+                       |> find_command
                        |> handle_command(
                          Enum.at(rest, 0),
                          state[message.user] || %{user: slack.users[message.user]}
@@ -26,17 +27,16 @@ defmodule FoodBot.SlackBot do
   end
   def handle_event(_, _, state), do: {:ok, state}
 
+  @commands %{
+    join_event: FoodBot.JoinEventCommand,
+    order: FoodBot.OrderCommand,
+  }
 
-  def handle_command(cmd, rest \\ nil, state \\ %{})
-
-  def handle_command("join_event", name, state) do
-    FoodBot.JoinEventCommand.execute(name, state)
-  end
-  def handle_command("order", text, state) do
-    FoodBot.OrderCommand.execute(text, state)
-  end
-  def handle_command(_, text, state) do
-    FoodBot.NotFoundCommand.execute(text, state)
+  def find_command(cmd) do
+    @commands[String.to_atom(cmd)] || FoodBot.NotFoundCommand
   end
 
+  def handle_command(cmd, rest \\ nil, state \\ %{}) do
+    cmd.execute(rest, state)
+  end
 end

--- a/lib/food_bot/slack_bot.ex
+++ b/lib/food_bot/slack_bot.ex
@@ -1,9 +1,6 @@
 defmodule FoodBot.SlackBot do
   use Slack
 
-  alias FoodBot.{Repo, Order}
-  import FoodBot.CommandHelpers
-
   def start_link() do
     Slack.Bot.start_link(__MODULE__, %{}, Application.get_env(:food_bot, :slack_bot_token))
   end
@@ -35,36 +32,8 @@ defmodule FoodBot.SlackBot do
   def handle_command("join_event", name, state) do
     FoodBot.JoinEventCommand.execute(name, state)
   end
-  def handle_command("order", nil, state) do
-    { "Sorry, you didn't provide an order.", state }
-  end
-  def handle_command("order", text, state = %{event: event, user: %{name: user_name}}) do
-    case Enum.count event.food_sources do
-      0 -> raise "TODO"
-      1 ->
-        {status, _} = Repo.insert %Order{
-          event: event,
-          food_source: Enum.at(event.food_sources, 0),
-          order: text,
-          user_name: user_name
-        }
-
-        case status do
-          :ok -> { "Your order has been taken. Thank you.", state }
-          :error -> { "Something went wrong while saving your order. :(", state }
-        end
-
-      _ -> raise "TODO"
-    end
-  end
-  def handle_command("order", _, state) do
-    {
-      """
-      Sorry, you need to join an event first. Is it one of these?
-      #{latest_events_text()}
-      """,
-      state
-    }
+  def handle_command("order", text, state) do
+    FoodBot.OrderCommand.execute(text, state)
   end
   def handle_command(_, _, state) do
     {

--- a/lib/food_bot/slack_bot.ex
+++ b/lib/food_bot/slack_bot.ex
@@ -35,11 +35,8 @@ defmodule FoodBot.SlackBot do
   def handle_command("order", text, state) do
     FoodBot.OrderCommand.execute(text, state)
   end
-  def handle_command(_, _, state) do
-    {
-      "Available commands are `join_event` and `current_event`",
-      state
-    }
+  def handle_command(_, text, state) do
+    FoodBot.NotFoundCommand.execute(text, state)
   end
 
 end

--- a/test/commands/join_event_command_test.exs
+++ b/test/commands/join_event_command_test.exs
@@ -1,0 +1,38 @@
+defmodule FoodBot.JoinEventCommandTest do
+  use FoodBot.BotCase
+  doctest FoodBot.JoinEventCommand
+
+  alias FoodBot.JoinEventCommand
+
+  test "adds event to state", context do
+    assert JoinEventCommand.execute("Tech Lunch") == {
+      """
+      You joined event "Tech Lunch". You can order from:
+       - Sushi Place: http://www.youmesushi.com/
+       - Mister Lasagna: http://misterlasagna.co.uk/our-menu#main-lasagna-dishes
+      """, %{event: context[:techLunch]}
+    }
+  end
+
+  test "event not found" do
+    assert JoinEventCommand.execute("Data Lunch") == {
+      """
+      Sorry, I can't find event "Data Lunch". Is it one of these?
+       - Design Lunch
+       - Tech Lunch
+      """,
+      %{}
+    }
+  end
+
+  test "no event name" do
+    assert JoinEventCommand.execute(nil) == {
+      """
+      Sorry, you didn't provide an event name. Is it one of these?
+       - Design Lunch
+       - Tech Lunch
+      """,
+      %{}
+    }
+  end
+end

--- a/test/commands/not_found_command_text.exs
+++ b/test/commands/not_found_command_text.exs
@@ -1,0 +1,12 @@
+defmodule FoodBot.NotFoundCommandTest do
+  use ExUnit.Case
+  doctest FoodBot.NotFoundCommand
+
+  alias FoodBot.NotFoundCommand
+
+  test "list available commands on unknown command" do
+    assert NotFoundCommand.execute() == {
+      "Available commands are `join_event` and `order`", %{}
+    }
+  end
+end

--- a/test/commands/order_command_test.exs
+++ b/test/commands/order_command_test.exs
@@ -1,0 +1,33 @@
+defmodule FoodBot.OrderCommandTest do
+  use FoodBot.BotCase
+  doctest FoodBot.OrderCommand
+
+  alias FoodBot.{OrderCommand, JoinEventCommand}
+
+  test "no event joined" do
+    assert OrderCommand.execute("Regular Funghi Lasagna") == {
+      """
+      Sorry, you need to join an event first. Is it one of these?
+       - Design Lunch
+       - Tech Lunch
+      """,
+      %{}
+    }
+  end
+
+  test "no order" do
+    assert OrderCommand.execute(nil) == {
+      "Sorry, you didn't provide an order.", %{}
+    }
+  end
+
+  test "single food source" do
+    {_, state} = JoinEventCommand.execute("Design Lunch")
+
+    state = Map.put state, :user, %{name: "pedro"}
+
+    assert OrderCommand.execute("Regular Funghi Lasagna", state) == {
+      "Your order has been taken. Thank you.", state
+    }
+  end
+end

--- a/test/slack_bot_test.exs
+++ b/test/slack_bot_test.exs
@@ -9,31 +9,4 @@ defmodule FoodBot.SlackBotTest do
       "Available commands are `join_event` and `current_event`", %{}
     }
   end
-
-  test "order command: no event joined" do
-    assert SlackBot.handle_command("order", "Regular Funghi Lasagna") == {
-      """
-      Sorry, you need to join an event first. Is it one of these?
-       - Design Lunch
-       - Tech Lunch
-      """,
-      %{}
-    }
-  end
-
-  test "order command: no order" do
-    assert SlackBot.handle_command("order") == {
-      "Sorry, you didn't provide an order.", %{}
-    }
-  end
-
-  test "order command: single food source" do
-    {_, state} = SlackBot.handle_command("join_event", "Design Lunch")
-
-    state = Map.put state, :user, %{name: "pedro"}
-
-    assert SlackBot.handle_command("order", "Regular Funghi Lasagna", state) == {
-      "Your order has been taken. Thank you.", state
-    }
-  end
 end

--- a/test/slack_bot_test.exs
+++ b/test/slack_bot_test.exs
@@ -4,5 +4,15 @@ defmodule FoodBot.SlackBotTest do
 
   alias FoodBot.SlackBot
 
-  # TODO: test handle_event function
+  test "finds join_event command" do
+    assert SlackBot.find_command("join_event") == FoodBot.JoinEventCommand
+  end
+
+  test "finds order command" do
+    assert SlackBot.find_command("order") == FoodBot.OrderCommand
+  end
+
+  test "default to not found command" do
+    assert SlackBot.find_command("...") == FoodBot.NotFoundCommand
+  end
 end

--- a/test/slack_bot_test.exs
+++ b/test/slack_bot_test.exs
@@ -1,73 +1,12 @@
 defmodule FoodBot.SlackBotTest do
-  use ExUnit.Case
+  use FoodBot.BotCase
   doctest FoodBot.SlackBot
 
-  alias FoodBot.{SlackBot, Repo, Event, FoodSource}
-
-
-  setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-
-    Repo.insert! %FoodSource{name: "Japanese Canteen"}
-
-    sushiPlace = Repo.insert! %FoodSource{
-      name: "Sushi Place",
-      url: "http://www.youmesushi.com/"
-    }
-
-    misterLasagna = Repo.insert! %FoodSource{
-      name: "Mister Lasagna",
-      url: "http://misterlasagna.co.uk/our-menu#main-lasagna-dishes"
-    }
-
-    techLunch = Repo.insert! %Event{
-      name: "Tech Lunch",
-      food_sources: [sushiPlace, misterLasagna]
-    }
-
-    Repo.insert! %Event{
-      name: "Design Lunch",
-      food_sources: [misterLasagna]
-    }
-
-    [techLunch: techLunch]
-  end
+  alias FoodBot.SlackBot
 
   test "list available commands on unknown command" do
     assert SlackBot.handle_command("unknown") == {
       "Available commands are `join_event` and `current_event`", %{}
-    }
-  end
-
-  test "join_event command: adds event to state", context do
-    assert SlackBot.handle_command("join_event", "Tech Lunch") == {
-      """
-      You joined event "Tech Lunch". You can order from:
-       - Sushi Place: http://www.youmesushi.com/
-       - Mister Lasagna: http://misterlasagna.co.uk/our-menu#main-lasagna-dishes
-      """, %{event: context[:techLunch]}
-    }
-  end
-
-  test "join_event command: event not found" do
-    assert SlackBot.handle_command("join_event", "Data Lunch") == {
-      """
-      Sorry, I can't find event "Data Lunch". Is it one of these?
-       - Design Lunch
-       - Tech Lunch
-      """,
-      %{}
-    }
-  end
-
-  test "join_event command: no event name" do
-    assert SlackBot.handle_command("join_event") == {
-      """
-      Sorry, you didn't provide an event name. Is it one of these?
-       - Design Lunch
-       - Tech Lunch
-      """,
-      %{}
     }
   end
 

--- a/test/slack_bot_test.exs
+++ b/test/slack_bot_test.exs
@@ -4,9 +4,5 @@ defmodule FoodBot.SlackBotTest do
 
   alias FoodBot.SlackBot
 
-  test "list available commands on unknown command" do
-    assert SlackBot.handle_command("unknown") == {
-      "Available commands are `join_event` and `current_event`", %{}
-    }
-  end
+  # TODO: test handle_event function
 end

--- a/test/support/bot_case.ex
+++ b/test/support/bot_case.ex
@@ -1,0 +1,33 @@
+defmodule FoodBot.BotCase do
+  use ExUnit.CaseTemplate
+
+  alias FoodBot.{Repo, Event, FoodSource}
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    Repo.insert! %FoodSource{name: "Japanese Canteen"}
+
+    sushiPlace = Repo.insert! %FoodSource{
+      name: "Sushi Place",
+      url: "http://www.youmesushi.com/"
+    }
+
+    misterLasagna = Repo.insert! %FoodSource{
+      name: "Mister Lasagna",
+      url: "http://misterlasagna.co.uk/our-menu#main-lasagna-dishes"
+    }
+
+    techLunch = Repo.insert! %Event{
+      name: "Tech Lunch",
+      food_sources: [sushiPlace, misterLasagna]
+    }
+
+    Repo.insert! %Event{
+      name: "Design Lunch",
+      food_sources: [misterLasagna]
+    }
+
+    [techLunch: techLunch]
+  end
+end


### PR DESCRIPTION
I wanted to add tests for `SlackBot.handle_event` and refactor `SlackBot` a bit but didn't manage to do to it last Friday. I can do it on a separate PR or will add to this one later.